### PR TITLE
Bulk Indexing Bleve Search Engine Enhancements

### DIFF
--- a/indexer/index_segment_storage.go
+++ b/indexer/index_segment_storage.go
@@ -1,8 +1,0 @@
-package indexer
-
-// IndexSegmentStorage defines the interface for storing index segments.
-// In a real system, this would interact with S3, GCS, etc.
-type IndexSegmentStorage interface {
-	UploadSegment(segmentPath string) error
-	// Potentially add methods for listing/downloading segments if needed later by other services.
-}

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -84,6 +84,28 @@ func (i *Indexer) DeleteDocument(id string) error {
 	return nil
 }
 
+// BulkIndexDocuments adds or updates multiple documents in the index using a batch.
+func (i *Indexer) BulkIndexDocuments(docs map[string]interface{}) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	log.Printf("Attempting to bulk index %d documents", len(docs))
+	batch := i.index.NewBatch()
+
+	for id, data := range docs {
+		log.Printf("Adding document %s to batch", id)
+		batch.Index(id, data)
+	}
+
+	if err := i.index.Batch(batch); err != nil {
+		log.Printf("Failed to execute batch index operation: %v", err)
+		return fmt.Errorf("failed to execute batch index operation: %w", err)
+	}
+
+	log.Printf("Successfully processed batch for %d documents", len(docs))
+	return nil
+}
+
 // CommitAndUpload commits the current index changes and uploads the index state.
 // In Bleve, indexing operations are eventually consistent. A 'commit' might mean
 // waiting for pending operations or creating a snapshot point. Uploading means

--- a/indexer/storage.go
+++ b/indexer/storage.go
@@ -6,6 +6,13 @@ import (
 	"os"
 )
 
+// IndexSegmentStorage defines the interface for storing index segments.
+// In a real system, this would interact with S3, GCS, etc.
+type IndexSegmentStorage interface {
+	UploadSegment(segmentPath string) error
+	// Potentially add methods for listing/downloading segments if needed later by other services.
+}
+
 // LocalFileStorage implements IndexSegmentStorage for local filesystem.
 // This is a stand-in for cloud storage like S3.
 type LocalFileStorage struct {


### PR DESCRIPTION
```
Add functionality to handle "full index build cycle" for bulk indexing operations, distinct from real-time updates. This might involve:
    *   A separate API endpoint or message queue consumer for bulk data.
    *   Batching index operations for efficiency during bulk imports.
    *   Potentially a mechanism to trigger a full index rebuild or a separate index instance for bulk processing, as suggested by "applied during the next full index build cycle."
    *   Integrating this bulk processing with the `CommitAndUpload` mechanism.
```