### PR TITLE
Query Understanding Service Review Analysis

### DIFF
--- a/query_understanding/config/default_stopwords.yaml
+++ b/query_understanding/config/default_stopwords.yaml
@@ -1,0 +1,26 @@
+stopwords:
+  - a
+  - an
+  - and
+  - are
+  - as
+  - at
+  - be
+  - by
+  - for
+  - from
+  - has
+  - he
+  - in
+  - is
+  - it
+  - its
+  - of
+  - on
+  - that
+  - the
+  - to
+  - was
+  - were
+  - will
+  - with

--- a/query_understanding/main.go
+++ b/query_understanding/main.go
@@ -3,10 +3,12 @@ package query_understanding
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"log"
 	"os"
 
 	"gopkg.in/yaml.v2"
+
+	"query_understanding/processing"
 )
 
 // DataType defines the type of data for an index field.
@@ -37,11 +39,67 @@ type ComputedField struct {
 	Expression string `json:"expression" yaml:"expression"` // e.g., "first_name + ' ' + last_name"
 }
 
+// QueryPlanningPipeline represents a sequence of stages for query processing.
+type QueryPlanningPipeline struct {
+	Name   string   `json:"name" yaml:"name"`     // Name of the pipeline
+	Stages []string `json:"stages" yaml:"stages"` // Example: "tokenize", "lowercase", "remove_stopwords", "synonym_expansion"
+}
+
 // IndexConfiguration holds the complete configuration for an index, including fields, computed fields, and pipelines.
 type IndexConfiguration struct {
 	IndexFields    []IndexField            `json:"index_fields" yaml:"index_fields"`
 	ComputedFields []ComputedField         `json:"computed_fields" yaml:"computed_fields"`
 	Pipelines      []QueryPlanningPipeline `json:"pipelines" yaml:"pipelines"`
+}
+
+// stopwordsConfig is a helper struct to unmarshal the stopwords YAML file.
+type stopwordsConfig struct {
+	Stopwords []string `yaml:"stopwords"`
+}
+
+var (
+	stageRegistry    *processing.StageRegistry
+	pipelineExecutor *processing.PipelineExecutor
+	defaultStopwords []string
+)
+
+// init initializes the query understanding service components.
+func init() {
+	stageRegistry = processing.NewStageRegistry()
+
+	// Register core query processing stages
+	if err := stageRegistry.Register("lowercase", &processing.LowerCaseStage{}); err != nil {
+		log.Fatalf("Failed to register lowercase stage: %v", err)
+	}
+	if err := stageRegistry.Register("tokenize", &processing.TokenizeStage{}); err != nil {
+		log.Fatalf("Failed to register tokenize stage: %v", err)
+	}
+
+	// Load default stopwords
+	stopwordsFilePath := "search-engine/query_understanding/config/default_stopwords.yaml"
+	data, err := os.ReadFile(stopwordsFilePath)
+	if err != nil {
+		log.Fatalf("Failed to read stopwords file %s: %v", stopwordsFilePath, err)
+	}
+
+	var swConfig stopwordsConfig
+	if err := yaml.Unmarshal(data, &swConfig); err != nil {
+		log.Fatalf("Failed to unmarshal stopwords file %s: %v", stopwordsFilePath, err)
+	}
+	defaultStopwords = swConfig.Stopwords
+
+	// Register RemoveStopwordsStage
+	// Note: The stopwords are passed as config during pipeline execution if needed,
+	//       but here we simply register the stage itself.
+	if err := stageRegistry.Register("remove_stopwords", &processing.RemoveStopwordsStage{}); err != nil {
+		log.Fatalf("Failed to register remove_stopwords stage: %v", err)
+	}
+
+	if err := stageRegistry.Register("synonym_expansion", &processing.SynonymExpansionStage{}); err != nil {
+		log.Fatalf("Failed to register synonym_expansion stage: %v", err)
+	}
+
+	pipelineExecutor = processing.NewPipelineExecutor(stageRegistry)
 }
 
 // LoadIndexConfiguration loads index configuration from a YAML file.
@@ -50,7 +108,7 @@ func LoadIndexConfiguration(filePath string) (*IndexConfiguration, error) {
 		return nil, fmt.Errorf("configuration file not found: %s", filePath)
 	}
 
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read configuration file %s: %w", filePath, err)
 	}
@@ -117,9 +175,54 @@ func (ic *IndexConfiguration) Validate() error {
 	return nil
 }
 
-// QueryPlanningPipeline represents a sequence of stages for query processing.
-// This is a placeholder for future implementation.
-type QueryPlanningPipeline struct {
-	Name   string   `json:"name" yaml:"name"`     // Name of the pipeline
-	Stages []string `json:"stages" yaml:"stages"` // Example: "tokenize", "lowercase", "remove_stopwords", "synonym_expansion"
+// ProcessClientQuery is the main entry point for processing a raw client query.
+// It takes the raw query string and the specific index configuration,
+// then processes it through the "default_pipeline" or a pipeline specified by the configuration.
+func ProcessClientQuery(rawQuery string, config *IndexConfiguration) (string, error) {
+	// For simplicity, we'll assume a "default_pipeline" exists and use it.
+	// In a more complex scenario, the pipeline to use could be determined by
+	// domain-specific rules or an explicit parameter in the client query.
+
+	// Find the pipeline named "default_pipeline"
+	pipelineName := "default_pipeline"
+	var defaultPipeline *QueryPlanningPipeline
+	for _, p := range config.Pipelines {
+		if p.Name == pipelineName {
+			defaultPipeline = &p
+			break
+		}
+	}
+
+	if defaultPipeline == nil {
+		return "", fmt.Errorf("default_pipeline not found in the provided index configuration")
+	}
+
+	// Prepare stage-specific configurations.
+	// For RemoveStopwordsStage, we need to pass the stopwords list.
+	stageConfigs := make(map[string]map[string]interface{})
+	stageConfigs["remove_stopwords"] = map[string]interface{}{
+		"stopwords": defaultStopwords,
+	}
+
+	currentQuery := rawQuery
+	for _, stageName := range defaultPipeline.Stages {
+		stage, found := stageRegistry.Get(stageName)
+		if !found {
+			return "", fmt.Errorf("query stage '%s' not found in registry for pipeline '%s'", stageName, pipelineName)
+		}
+
+		// Get stage-specific config, if any
+		configForStage := stageConfigs[stageName]
+		if configForStage == nil {
+			configForStage = make(map[string]interface{}) // Ensure it's not nil
+		}
+
+		processedQuery, err := stage.Process(currentQuery, configForStage)
+		if err != nil {
+			return "", fmt.Errorf("failed to execute stage '%s' in pipeline '%s': %w", stageName, pipelineName, err)
+		}
+		currentQuery = processedQuery
+	}
+
+	return currentQuery, nil
 }

--- a/query_understanding/main.go
+++ b/query_understanding/main.go
@@ -1,56 +1,15 @@
 package query_understanding
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
 
-	"gopkg.in/yaml.v2"
-
+	"query_understanding/config"
 	"query_understanding/processing"
+
+	"gopkg.in/yaml.v2"
 )
-
-// DataType defines the type of data for an index field.
-type DataType int
-
-const (
-	STRING DataType = iota
-	INTEGER
-	FLOAT
-	BOOLEAN
-	DATETIME
-)
-
-// IndexField defines the schema for a single field within an index.
-type IndexField struct {
-	FieldName    string   `json:"field_name" yaml:"field_name"`
-	DataType     DataType `json:"data_type" yaml:"data_type"`
-	Indexed      bool     `json:"indexed" yaml:"indexed"`
-	Stored       bool     `json:"stored" yaml:"stored"`
-	Sortable     bool     `json:"sortable" yaml:"sortable"`
-	Aggregatable bool     `json:"aggregatable" yaml:"aggregatable"`
-	Analyzer     string   `json:"analyzer" yaml:"analyzer"` // e.g., "standard", "keyword", "whitespace"
-}
-
-// ComputedField defines a field whose value is derived from an expression based on other fields.
-type ComputedField struct {
-	FieldName  string `json:"field_name" yaml:"field_name"`
-	Expression string `json:"expression" yaml:"expression"` // e.g., "first_name + ' ' + last_name"
-}
-
-// QueryPlanningPipeline represents a sequence of stages for query processing.
-type QueryPlanningPipeline struct {
-	Name   string   `json:"name" yaml:"name"`     // Name of the pipeline
-	Stages []string `json:"stages" yaml:"stages"` // Example: "tokenize", "lowercase", "remove_stopwords", "synonym_expansion"
-}
-
-// IndexConfiguration holds the complete configuration for an index, including fields, computed fields, and pipelines.
-type IndexConfiguration struct {
-	IndexFields    []IndexField            `json:"index_fields" yaml:"index_fields"`
-	ComputedFields []ComputedField         `json:"computed_fields" yaml:"computed_fields"`
-	Pipelines      []QueryPlanningPipeline `json:"pipelines" yaml:"pipelines"`
-}
 
 // stopwordsConfig is a helper struct to unmarshal the stopwords YAML file.
 type stopwordsConfig struct {
@@ -76,7 +35,7 @@ func init() {
 	}
 
 	// Load default stopwords
-	stopwordsFilePath := "search-engine/query_understanding/config/default_stopwords.yaml"
+	stopwordsFilePath := "config/default_stopwords.yaml"
 	data, err := os.ReadFile(stopwordsFilePath)
 	if err != nil {
 		log.Fatalf("Failed to read stopwords file %s: %v", stopwordsFilePath, err)
@@ -102,127 +61,44 @@ func init() {
 	pipelineExecutor = processing.NewPipelineExecutor(stageRegistry)
 }
 
-// LoadIndexConfiguration loads index configuration from a YAML file.
-func LoadIndexConfiguration(filePath string) (*IndexConfiguration, error) {
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("configuration file not found: %s", filePath)
-	}
-
-	data, err := os.ReadFile(filePath)
+// LoadConfiguration loads the main service configuration from a YAML file.
+func LoadConfiguration(filePath string) (*config.Configuration, error) {
+	cfg, err := config.LoadConfig(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read configuration file %s: %w", filePath, err)
+		return nil, fmt.Errorf("failed to load main configuration: %w", err)
 	}
-
-	var config IndexConfiguration
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal configuration file %s: %w", filePath, err)
-	}
-
-	return &config, nil
-}
-
-// Validate performs basic validation on the IndexConfiguration.
-func (ic *IndexConfiguration) Validate() error {
-	fieldNames := make(map[string]bool)
-
-	// Validate IndexFields
-	for _, field := range ic.IndexFields {
-		if field.FieldName == "" {
-			return errors.New("index field name cannot be empty")
-		}
-		if fieldNames[field.FieldName] {
-			return fmt.Errorf("duplicate index field name found: %s", field.FieldName)
-		}
-		fieldNames[field.FieldName] = true
-
-		// Basic data type validation
-		// Assuming DATETIME is the last valid enum value.
-		if field.DataType < STRING || field.DataType > DATETIME {
-			return fmt.Errorf("invalid data type '%d' for field '%s'", field.DataType, field.FieldName)
-		}
-		// Further validation for analyzer etc. could go here
-	}
-
-	// Validate ComputedFields
-	for _, field := range ic.ComputedFields {
-		if field.FieldName == "" {
-			return errors.New("computed field name cannot be empty")
-		}
-		if fieldNames[field.FieldName] {
-			return fmt.Errorf("duplicate field name (index or computed) found: %s", field.FieldName)
-		}
-		fieldNames[field.FieldName] = true
-		if field.Expression == "" {
-			return fmt.Errorf("computed field '%s' must have an expression", field.FieldName)
-		}
-	}
-
-	// Validate Pipelines
-	pipelineNames := make(map[string]bool)
-	for _, pipeline := range ic.Pipelines {
-		if pipeline.Name == "" {
-			return errors.New("query planning pipeline name cannot be empty")
-		}
-		if pipelineNames[pipeline.Name] {
-			return fmt.Errorf("duplicate query planning pipeline name found: %s", pipeline.Name)
-		}
-		pipelineNames[pipeline.Name] = true
-		if len(pipeline.Stages) == 0 {
-			return fmt.Errorf("query planning pipeline '%s' must have at least one stage", pipeline.Name)
-		}
-	}
-
-	return nil
+	return cfg, nil
 }
 
 // ProcessClientQuery is the main entry point for processing a raw client query.
-// It takes the raw query string and the specific index configuration,
+// It takes the raw query string and the specific service configuration,
 // then processes it through the "default_pipeline" or a pipeline specified by the configuration.
-func ProcessClientQuery(rawQuery string, config *IndexConfiguration) (string, error) {
-	// For simplicity, we'll assume a "default_pipeline" exists and use it.
-	// In a more complex scenario, the pipeline to use could be determined by
-	// domain-specific rules or an explicit parameter in the client query.
+func ProcessClientQuery(rawQuery string, cfg *config.Configuration) (string, error) {
+	pipelineName := "default_pipeline" // For simplicity, assume default_pipeline
 
-	// Find the pipeline named "default_pipeline"
-	pipelineName := "default_pipeline"
-	var defaultPipeline *QueryPlanningPipeline
-	for _, p := range config.Pipelines {
-		if p.Name == pipelineName {
-			defaultPipeline = &p
+	var defaultPipeline *config.QueryPlanningPipeline
+	for i := range cfg.QueryPlanningPipelines {
+		if cfg.QueryPlanningPipelines[i].Name == pipelineName {
+			defaultPipeline = &cfg.QueryPlanningPipelines[i]
 			break
 		}
 	}
 
 	if defaultPipeline == nil {
-		return "", fmt.Errorf("default_pipeline not found in the provided index configuration")
+		return "", fmt.Errorf("query planning pipeline '%s' not found in the provided configuration", pipelineName)
 	}
 
 	// Prepare stage-specific configurations.
-	// For RemoveStopwordsStage, we need to pass the stopwords list.
 	stageConfigs := make(map[string]map[string]interface{})
 	stageConfigs["remove_stopwords"] = map[string]interface{}{
 		"stopwords": defaultStopwords,
 	}
 
-	currentQuery := rawQuery
-	for _, stageName := range defaultPipeline.Stages {
-		stage, found := stageRegistry.Get(stageName)
-		if !found {
-			return "", fmt.Errorf("query stage '%s' not found in registry for pipeline '%s'", stageName, pipelineName)
-		}
-
-		// Get stage-specific config, if any
-		configForStage := stageConfigs[stageName]
-		if configForStage == nil {
-			configForStage = make(map[string]interface{}) // Ensure it's not nil
-		}
-
-		processedQuery, err := stage.Process(currentQuery, configForStage)
-		if err != nil {
-			return "", fmt.Errorf("failed to execute stage '%s' in pipeline '%s': %w", stageName, pipelineName, err)
-		}
-		currentQuery = processedQuery
+	// Execute the pipeline using the PipelineExecutor
+	processedQuery, err := pipelineExecutor.ExecutePipeline(defaultPipeline, rawQuery, stageConfigs)
+	if err != nil {
+		return "", fmt.Errorf("failed to process query with pipeline '%s': %w", pipelineName, err)
 	}
 
-	return currentQuery, nil
+	return processedQuery, nil
 }

--- a/query_understanding/processing/interfaces.go
+++ b/query_understanding/processing/interfaces.go
@@ -1,0 +1,8 @@
+package processing
+
+// QueryStage defines the interface for a single stage in the query processing pipeline.
+// Each stage takes a query string and a map of configuration parameters, processes it,
+// and returns the modified query string or an error.
+type QueryStage interface {
+	Process(query string, config map[string]interface{}) (string, error)
+}

--- a/query_understanding/processing/pipeline_executor.go
+++ b/query_understanding/processing/pipeline_executor.go
@@ -1,0 +1,54 @@
+package processing
+
+import (
+	"fmt"
+
+	"query_understanding"
+)
+
+// PipelineExecutor is responsible for executing a sequence of query processing stages.
+type PipelineExecutor struct {
+	registry *StageRegistry
+}
+
+// NewPipelineExecutor creates a new PipelineExecutor with the given StageRegistry.
+func NewPipelineExecutor(registry *StageRegistry) *PipelineExecutor {
+	return &PipelineExecutor{
+		registry: registry,
+	}
+}
+
+// ExecutePipeline processes a raw query string through a specified query planning pipeline.
+// It retrieves the pipeline definition from the provided IndexConfiguration and applies
+// each stage in sequence.
+func (pe *PipelineExecutor) ExecutePipeline(pipelineName string, rawQuery string, config *query_understanding.IndexConfiguration) (string, error) {
+	var pipeline *query_understanding.QueryPlanningPipeline
+	for i := range config.Pipelines {
+		if config.Pipelines[i].Name == pipelineName {
+			pipeline = &config.Pipelines[i]
+			break
+		}
+	}
+
+	if pipeline == nil {
+		return "", fmt.Errorf("query planning pipeline '%s' not found in configuration", pipelineName)
+	}
+
+	currentQuery := rawQuery
+	for _, stageName := range pipeline.Stages {
+		stage, found := pe.registry.Get(stageName)
+		if !found {
+			return "", fmt.Errorf("query stage '%s' not found in registry for pipeline '%s'", stageName, pipelineName)
+		}
+
+		// Placeholder for stage-specific configuration. For now, passing an empty map.
+		// In future, configuration could be resolved from config.yaml based on stageName.
+		processedQuery, err := stage.Process(currentQuery, make(map[string]interface{}))
+		if err != nil {
+			return "", fmt.Errorf("failed to execute stage '%s' in pipeline '%s': %w", stageName, pipelineName, err)
+		}
+		currentQuery = processedQuery
+	}
+
+	return currentQuery, nil
+}

--- a/query_understanding/processing/registry.go
+++ b/query_understanding/processing/registry.go
@@ -1,0 +1,42 @@
+package processing
+
+import (
+	"fmt"
+	"sync"
+)
+
+// StageRegistry manages the registration and retrieval of QueryStage implementations.
+type StageRegistry struct {
+	mu     sync.RWMutex
+	stages map[string]QueryStage
+}
+
+// NewStageRegistry creates and returns a new, empty StageRegistry.
+func NewStageRegistry() *StageRegistry {
+	return &StageRegistry{
+		stages: make(map[string]QueryStage),
+	}
+}
+
+// Register adds a QueryStage implementation to the registry under a given name.
+// It returns an error if a stage with the same name is already registered.
+func (sr *StageRegistry) Register(name string, stage QueryStage) error {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	if _, exists := sr.stages[name]; exists {
+		return fmt.Errorf("query stage '%s' is already registered", name)
+	}
+	sr.stages[name] = stage
+	return nil
+}
+
+// Get retrieves a QueryStage implementation by its registered name.
+// It returns the stage and true if found, otherwise nil and false.
+func (sr *StageRegistry) Get(name string) (QueryStage, bool) {
+	sr.mu.RLock()
+	defer sr.mu.RUnlock()
+
+	stage, found := sr.stages[name]
+	return stage, found
+}

--- a/query_understanding/processing/stages.go
+++ b/query_understanding/processing/stages.go
@@ -1,0 +1,83 @@
+package processing
+
+import (
+	"errors"
+	"strings"
+)
+
+// LowerCaseStage implements the QueryStage interface to convert the query to lowercase.
+type LowerCaseStage struct{}
+
+// Process converts the input query string to lowercase.
+func (s *LowerCaseStage) Process(query string, config map[string]interface{}) (string, error) {
+	return strings.ToLower(query), nil
+}
+
+// TokenizeStage implements the QueryStage interface to split the query into tokens.
+type TokenizeStage struct{}
+
+// Process splits the input query string into tokens based on whitespace.
+// It returns a space-separated string of tokens.
+func (s *TokenizeStage) Process(query string, config map[string]interface{}) (string, error) {
+	if query == "" {
+		return "", nil
+	}
+	// Simple whitespace tokenizer. More advanced tokenization would involve regex or libraries.
+	tokens := strings.Fields(query)
+	return strings.Join(tokens, " "), nil
+}
+
+// RemoveStopwordsStage implements the QueryStage interface to remove stopwords from the query.
+type RemoveStopwordsStage struct{}
+
+// Process removes predefined stopwords from the query.
+// Stopwords are expected in the config map under the "stopwords" key as a []string.
+func (s *RemoveStopwordsStage) Process(query string, config map[string]interface{}) (string, error) {
+	if query == "" {
+		return "", nil
+	}
+
+	stopwordsInterface, ok := config["stopwords"]
+	if !ok {
+		// If no stopwords are provided in config, simply return the original query.
+		// Alternatively, this could return an error or use a default list.
+		return query, nil
+	}
+
+	stopwordsList, ok := stopwordsInterface.([]string)
+	if !ok {
+		return "", errors.New("stopwords config must be a list of strings")
+	}
+
+	stopwordMap := make(map[string]struct{})
+	for _, sw := range stopwordsList {
+		stopwordMap[sw] = struct{}{}
+	}
+
+	// Assuming the query is already tokenized by a previous stage or is space-separated.
+	tokens := strings.Fields(query)
+	filteredTokens := make([]string, 0, len(tokens))
+
+	for _, token := range tokens {
+		if _, isStopword := stopwordMap[token]; !isStopword {
+			filteredTokens = append(filteredTokens, token)
+		}
+	}
+
+	return strings.Join(filteredTokens, " "), nil
+}
+
+// SynonymExpansionStage implements the QueryStage interface for synonym expansion.
+// This is a placeholder and would require a more complex lookup mechanism.
+type SynonymExpansionStage struct{}
+
+// Process currently returns the query as is, demonstrating a placeholder.
+// In a real scenario, this would expand terms based on a synonym dictionary.
+func (s *SynonymExpansionStage) Process(query string, config map[string]interface{}) (string, error) {
+	// For demonstration, let's say "pc" expands to "personal computer"
+	// This logic would typically come from a configurable synonym map
+	if strings.Contains(query, "pc") {
+		query = strings.ReplaceAll(query, "pc", "pc personal computer")
+	}
+	return query, nil
+}


### PR DESCRIPTION
**Query Understanding and Planning Service:** This component is crucial for processing raw client queries. It holds knowledge specific to a particular index and its business domain. The Broker uses this service to transform the user's query into a planned query that can be efficiently executed by the Searchers. Consolidating this logic here prevents individual clients from needing to replicate complex query-building logic. Review this service implementation and it covers:
    *   Design a data model for defining index schemas, computed fields, and query planning pipelines using declarative configurations.
    *   Implement logic to process raw queries based on these configurations and domain-specific rules.